### PR TITLE
แสดงวันที่ของข้อมูลการฉีดวัคซีนที่ได้รับมา

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,8 +31,9 @@ const calcProgressBar = () => {
   let progressNum1Dose = `\n\n1st dose: ${data.people_vaccinated} (+${data.first_dose_plus})`
   let progressNum2Dose = `\n2nd dose: ${data.people_fully_vaccinated} (+${data.second_dose_plus})`
   let progressNumTotal = `\nTotal: ${data.total_vaccinations} (+${data.total_dose_plus})`
+  let dateOfData = `\n\n(As of ${data.date})`
   // combine all sections
-  let progress = progressBar1 + progressBar2 + progressNum1Dose + progressNum2Dose + progressNumTotal
+  let progress = progressBar1 + progressBar2 + progressNum1Dose + progressNum2Dose + progressNumTotal + dateOfData
   // add to array
   thread.push(progress)
   console.log(thread);


### PR DESCRIPTION
เนื่องจากทวิตบอทจะทวีตข้อมูลดีเลย์จากวันที่ของข้อมูลนั้น 1 วัน จึงเพิ่มวันที่ลงไปในทวิตเพื่อแจ้งให้ทราบถึงวันที่เก็บข้อมูลครับ

ยังไม่ได้ลองเทสว่าเวิร์คไหม หรือ เกินโควต้าจำนวนทวิตไหมนะครับ ไม่ชัวร์ว่าต้องรันเทสยังไง